### PR TITLE
Orient line rectangles properly in 3D scenes

### DIFF
--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -12,18 +12,20 @@ varying vec4 fragColor;
 varying vec3 worldPosition;
 varying float pixelArcLength;
 
-vec3 project(vec3 p) {
-  vec4 pp = projection * view * model * vec4(p, 1.0);
-  return pp.xyz / pp.w;
+vec4 project(vec3 p) {
+  return projection * view * model * vec4(p, 1.0);
 }
 
 void main() {
-  vec3 startPoint = project(position);
-  vec3 endPoint   = project(nextPosition);
+  vec4 startPoint = project(position);
+  vec4 endPoint   = project(nextPosition);
+
+  vec2 A = startPoint.xy / startPoint.w;
+  vec2 B =   endPoint.xy /   endPoint.w;
 
   float clipAngle = atan(
-    (endPoint.y - startPoint.y) * screenShape.y,
-    (endPoint.x - startPoint.x) * screenShape.x
+    (B.y - A.y) * screenShape.y,
+    (B.x - A.x) * screenShape.x
   );
 
   vec2 offset = 0.5 * pixelRatio * lineWidth * vec2(
@@ -31,7 +33,7 @@ void main() {
     -cos(clipAngle)
   ) / screenShape;
 
-  gl_Position = vec4(startPoint.xy + offset, startPoint.z, 1.0);
+  gl_Position = vec4(startPoint.xy + startPoint.w * offset, startPoint.zw);
 
   worldPosition = position;
   pixelArcLength = arcLength;

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -14,7 +14,7 @@ varying float pixelArcLength;
 
 vec3 project(vec3 p) {
   vec4 pp = projection * view * model * vec4(p, 1.0);
-  return pp.xyz / max(pp.w, 0.0001);
+  return pp.xyz / pp.w;
 }
 
 void main() {


### PR DESCRIPTION
Previously the angles computed in this module necessary to match rectangle shapes towards camera point were not accurate. Therefore 2D representations of 3D lines were not oriented properly in various perspective angles. Disappearing and tininess impacts resulted from the bug could be clearly observed namely when the thicknesses of lines using `scatter3d` were increased. Please refer to the Plotly [issue](https://github.com/plotly/plotly.js/issues/691) #691 and Plotly [PR](https://github.com/plotly/plotly.js/pull/3128) for more information.
This PR tries to improve rendering of lines in 3D scenes by performing proper 3D/2D calculations within the webgl vertex shader of this module.
@alexcjohnson 