### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -13,7 +13,7 @@ varying vec3 worldPosition;
 varying float pixelArcLength;
 
 vec4 project(vec3 p) {
-  return projection * view * model * vec4(p, 1.0);
+  return projection * (view * (model * vec4(p, 1.0)));
 }
 
 void main() {


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23